### PR TITLE
Fix query result column ordering to match SQL query order

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -280,7 +280,7 @@ func TestClient_DisplayJSONFile(t *testing.T) {
 	os.Stdout = w
 
 	client := &Client{debug: false}
-	err = client.displayJSONFile(tmpFile.Name())
+	err = client.displayJSONFile(tmpFile.Name(), []ColumnInfo{})
 
 	w.Close()
 	os.Stdout = oldStdout


### PR DESCRIPTION
## Summary
- Fix column ordering in query results to match the order specified in SQL queries
- Use API-provided column metadata instead of relying on random map iteration
- Maintain backward compatibility for cases where column info is not available

## Problem
Query results were displaying columns in random order due to Go's randomized map iteration order, making the output inconsistent and confusing for users.

**Before:**
```sql
SELECT operator_id, subscription, count(*) FROM sim_snapshots;
```
```
┌──────────┬──────────────┬──────────────┐
│ COUNT(*) │ OPERATOR_ID  │ SUBSCRIPTION │  ← Random order
├──────────┼──────────────┼──────────────┤
```

**After:**
```sql  
SELECT operator_id, subscription, count(*) FROM sim_snapshots;
```
```
┌──────────────┬──────────────┬──────────┐
│ OPERATOR_ID  │ SUBSCRIPTION │ COUNT(*) │  ← Matches SQL query order
├──────────────┼──────────────┼──────────┤
```

## Solution
The API response already includes `columnInfo` with the correct column order and metadata:
```json
{
  "columnInfo": [
    {"name": "OPERATOR_ID", "type": "string", "databaseType": "TEXT"},
    {"name": "SUBSCRIPTION", "type": "string", "databaseType": "TEXT"}, 
    {"name": "COUNT(*)", "type": "int64", "databaseType": "FIXED"}
  ]
}
```

## Changes
1. **Add `ColumnInfo` struct** to capture column metadata from API response
2. **Extend `QueryStatusResponse`** to include `columnInfo` field from API  
3. **Update `displayJSONFile`** to use API-provided column ordering first
4. **Maintain backward compatibility** with fallback to discovery-based ordering
5. **Fix test** to match new function signature

## Test plan
- [x] Verified fix works with original test query
- [x] Tested with different column orders (reordered SELECT fields)
- [x] Tested CSV output format maintains correct ordering  
- [x] Ensured all existing tests pass
- [x] Confirmed backward compatibility with empty column info

🤖 Generated with [Claude Code](https://claude.ai/code)